### PR TITLE
Fixed stop on walls

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -199,10 +199,12 @@ void Game::start()
 		switch(input)
 		{
 			case ((int) 's'): // move player left
+				if(map.get_chunk(current_chunk).is_there_a_platform(player.get_position() - phy::Point(0, 1)))
 					player.set_position(player.get_position() - phy::Point(1, 0));
 				break;
 
 			case ((int) 'd'): // move player right
+				if(map.get_chunk(current_chunk).is_there_a_platform(player.get_position() - phy::Point(0, 1)))
 					player.set_position(player.get_position() + phy::Point(1, 0));
 				break;
 			case 27:


### PR DESCRIPTION
Risolto il fatto che se uno si attaccava al muro e si spostava nella stessa direzione rimaneva incollato senza cadere. Si è inoltre risolto di conseguenza il fatto che un si poteva muovere mentre cadeva. Ora questo non è più possibile ed per fermarsi si è costretti a colpire una piattaforma.